### PR TITLE
Create A2A Agent Cards

### DIFF
--- a/multi-agent/manager/agent.py
+++ b/multi-agent/manager/agent.py
@@ -117,3 +117,11 @@ root_agent = Agent(
         read_file_content,
     ],
 )
+
+
+def get_a2a_app(host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the SOC Manager agent."""
+  from .utils.a2a import get_a2a_app_from_config
+  # Path to the YAML configuration file
+  config_path = (Path(__file__).resolve().parent / "config/agents/manager.yaml").resolve()
+  return get_a2a_app_from_config(root_agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/agent.py
+++ b/multi-agent/manager/agent.py
@@ -11,6 +11,7 @@ from .sub_agents.soc_analyst_tier3 import agent as soc_analyst_tier3_agent_modul
 from .sub_agents.incident_responder import agent as incident_responder_agent_module
 from .sub_agents.detection_engineer import agent as detection_engineer_agent_module
 from .sub_agents.llm_judge import agent as llm_judge_agent_module
+from .sub_agents.remote_assistant import agent as remote_assistant_agent_module
 
 from .tools.tools import get_current_time, write_report, get_agent_tools, load_persona_and_runbooks, read_file_content
 
@@ -29,6 +30,12 @@ initialized_soc_analyst_tier3 = soc_analyst_tier3_agent_module.get_agent(shared_
 initialized_incident_responder = incident_responder_agent_module.get_agent(shared_tools)
 initialized_detection_engineer = detection_engineer_agent_module.get_agent(shared_tools)
 initialized_llm_judge = llm_judge_agent_module.get_agent(shared_tools)
+# We assume remote assistant service is running on localhost:8001
+try:
+  initialized_remote_assistant = remote_assistant_agent_module.get_agent(shared_tools)
+except Exception as e:
+  logging.warning("Failed to initialize remote assistant agent: %s", e)
+  initialized_remote_assistant = None
 
 # Load persona and runbooks for the manager
 BASE_DIR = Path(__file__).resolve().parent
@@ -92,6 +99,7 @@ root_agent = Agent(
     - incident_responder: Hands-on execution of containment, eradication, and recovery phases of an incident as directed by an IRP or yourself.
     - detection_engineer: Designing, developing, testing, and tuning security detection rules and analytics.
     - llm_judge: Evaluating the quality and completeness of runbook executions by other agents.
+    - remote_assistant: A remote assistant available via A2A interface for general assistance.
 
     **Your Tools:**
     You have direct access to these tools for oversight and reporting:
@@ -102,6 +110,16 @@ root_agent = Agent(
     Always aim for clear, coordinated, and efficient execution of security operations, leveraging your sub-agents effectively according to their roles and the active IRP.
     """,
     sub_agents=[
+        initialized_soc_analyst_tier1,
+        initialized_soc_analyst_tier2,
+        initialized_cti_researcher,
+        initialized_threat_hunter,
+        initialized_soc_analyst_tier3,
+        initialized_incident_responder,
+        initialized_detection_engineer,
+        initialized_llm_judge,
+        initialized_remote_assistant,
+    ] if initialized_remote_assistant else [
         initialized_soc_analyst_tier1,
         initialized_soc_analyst_tier2,
         initialized_cti_researcher,

--- a/multi-agent/manager/config/agents/cti_researcher.yaml
+++ b/multi-agent/manager/config/agents/cti_researcher.yaml
@@ -1,0 +1,19 @@
+agent_name: cti_researcher
+display_name: "CTI Researcher"
+description: "Cyber Threat Intelligence researcher and analyst"
+expertise_areas:
+  - threat_intelligence_research
+  - actor_profiling
+  - campaign_analysis
+  - ioc_threat_hunt
+mcp_servers:
+  - name: gti-mcp
+    description: "Threat Intelligence"
+delegation_triggers:
+  - "threat intelligence"
+  - "threat actor"
+  - "campaign"
+  - "APT"
+capabilities:
+  can_escalate_to:
+    - threat_hunter

--- a/multi-agent/manager/config/agents/detection_engineer.yaml
+++ b/multi-agent/manager/config/agents/detection_engineer.yaml
@@ -1,0 +1,19 @@
+agent_name: detection_engineer
+display_name: "Detection Engineer"
+description: "Detection rule development and tuning specialist"
+expertise_areas:
+  - detection_rule_development
+  - rule_tuning
+  - detection_as_code
+  - analytics_management
+mcp_servers:
+  - name: secops-mcp
+    description: "SIEM operations"
+delegation_triggers:
+  - "detection rule"
+  - "tuning"
+  - "false positive"
+  - "new detection"
+capabilities:
+  can_escalate_to:
+    - manager

--- a/multi-agent/manager/config/agents/incident_responder.yaml
+++ b/multi-agent/manager/config/agents/incident_responder.yaml
@@ -1,0 +1,21 @@
+agent_name: incident_responder
+display_name: "Incident Responder"
+description: "Security incident containment, eradication, and recovery specialist"
+expertise_areas:
+  - incident_containment
+  - eradication
+  - recovery
+  - forensic_coordination
+mcp_servers:
+  - name: soar-mcp
+    description: "SOAR platform operations"
+  - name: secops-mcp
+    description: "SIEM operations"
+delegation_triggers:
+  - "containment"
+  - "eradication"
+  - "recovery"
+  - "active incident"
+capabilities:
+  can_escalate_to:
+    - manager

--- a/multi-agent/manager/config/agents/llm_judge.yaml
+++ b/multi-agent/manager/config/agents/llm_judge.yaml
@@ -1,0 +1,20 @@
+agent_name: llm_judge
+display_name: "LLM Judge"
+description: "Runbook execution evaluator"
+expertise_areas:
+  - runbook_evaluation
+  - quality_assurance
+  - compliance_check
+mcp_servers:
+  - name: internal_tools
+    description: "Internal tools"
+    tools:
+      - read_file_content
+      - write_report
+delegation_triggers:
+  - "evaluate"
+  - "review"
+  - "audit"
+capabilities:
+  can_escalate_to:
+    - manager

--- a/multi-agent/manager/config/agents/manager.yaml
+++ b/multi-agent/manager/config/agents/manager.yaml
@@ -1,0 +1,30 @@
+agent_name: manager
+display_name: "SOC Manager"
+description: "SOC operations orchestrator and delegator"
+expertise_areas:
+  - team_leadership
+  - operational_oversight
+  - incident_management
+  - reporting
+  - delegation
+mcp_servers:
+  - name: internal_tools
+    description: "Internal tools"
+    tools:
+      - write_report
+      - get_current_time
+      - read_file_content
+delegation_triggers:
+  - "manage"
+  - "coordinate"
+  - "report"
+capabilities:
+  can_delegate_to:
+    - soc_analyst_tier1
+    - soc_analyst_tier2
+    - soc_analyst_tier3
+    - cti_researcher
+    - threat_hunter
+    - incident_responder
+    - detection_engineer
+    - llm_judge

--- a/multi-agent/manager/config/agents/soc_analyst_tier1.yaml
+++ b/multi-agent/manager/config/agents/soc_analyst_tier1.yaml
@@ -1,0 +1,25 @@
+agent_name: soc_analyst_tier1
+display_name: "SOC Analyst Tier 1"
+description: "Initial alert triage and basic IOC enrichment specialist"
+expertise_areas:
+  - alert_triage
+  - basic_ioc_enrichment
+  - phishing_email_analysis
+  - suspicious_login_analysis
+mcp_servers:
+  - name: secops-mcp
+    description: "SIEM operations"
+  - name: gti-mcp
+    description: "Threat Intelligence"
+delegation_triggers:
+  - "triage"
+  - "alert"
+  - "suspicious login"
+  - "phishing"
+capabilities:
+  can_escalate_to:
+    - soc_analyst_tier2
+    - incident_responder
+  handles_alert_severity:
+    - low
+    - medium

--- a/multi-agent/manager/config/agents/soc_analyst_tier2.yaml
+++ b/multi-agent/manager/config/agents/soc_analyst_tier2.yaml
@@ -1,0 +1,28 @@
+agent_name: soc_analyst_tier2
+display_name: "SOC Analyst Tier 2"
+description: "Deep investigation and SOAR case management specialist"
+expertise_areas:
+  - deep_investigation
+  - soar_case_management
+  - advanced_ioc_analysis
+  - lateral_movement_analysis
+  - cloud_vulnerability_triage
+mcp_servers:
+  - name: soar-mcp
+    description: "SOAR platform operations"
+  - name: secops-mcp
+    description: "SIEM operations"
+  - name: gti-mcp
+    description: "Threat Intelligence"
+delegation_triggers:
+  - "SOAR case"
+  - "deep investigation"
+  - "case management"
+  - "lateral movement"
+capabilities:
+  can_escalate_to:
+    - soc_analyst_tier3
+    - incident_responder
+  handles_alert_severity:
+    - medium
+    - high

--- a/multi-agent/manager/config/agents/soc_analyst_tier3.yaml
+++ b/multi-agent/manager/config/agents/soc_analyst_tier3.yaml
@@ -1,0 +1,28 @@
+agent_name: soc_analyst_tier3
+display_name: "SOC Analyst Tier 3"
+description: "Advanced incident response and deep-dive analysis specialist"
+expertise_areas:
+  - advanced_incident_response
+  - deep_dive_analysis
+  - malware_triage
+  - ransomware_response
+  - compromised_user_response
+mcp_servers:
+  - name: soar-mcp
+    description: "SOAR platform operations"
+  - name: secops-mcp
+    description: "SIEM operations"
+  - name: gti-mcp
+    description: "Threat Intelligence"
+delegation_triggers:
+  - "escalated incident"
+  - "major security event"
+  - "ransomware"
+  - "compromised user"
+  - "malware"
+capabilities:
+  can_escalate_to:
+    - incident_responder
+  handles_alert_severity:
+    - high
+    - critical

--- a/multi-agent/manager/config/agents/threat_hunter.yaml
+++ b/multi-agent/manager/config/agents/threat_hunter.yaml
@@ -1,0 +1,21 @@
+agent_name: threat_hunter
+display_name: "Threat Hunter"
+description: "Proactive threat hunting specialist"
+expertise_areas:
+  - proactive_threat_hunting
+  - hypothesis_driven_investigation
+  - apt_hunting
+  - ttp_hunting
+mcp_servers:
+  - name: secops-mcp
+    description: "SIEM operations"
+  - name: gti-mcp
+    description: "Threat Intelligence"
+delegation_triggers:
+  - "hunt"
+  - "proactive"
+  - "hypothesis"
+capabilities:
+  can_escalate_to:
+    - soc_analyst_tier3
+    - incident_responder

--- a/multi-agent/manager/sub_agents/cti_researcher/agent.py
+++ b/multi-agent/manager/sub_agents/cti_researcher/agent.py
@@ -43,3 +43,11 @@ def get_agent(tools):
       tools=tools, # Use passed-in tools
   )
   return agent_instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the CTI Researcher agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/cti_researcher.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/detection_engineer/agent.py
+++ b/multi-agent/manager/sub_agents/detection_engineer/agent.py
@@ -48,3 +48,11 @@ def get_agent(tools):
       tools=tools, # Use passed-in tools
   )
   return agent_instance # Only return the agent instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the Detection Engineer agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/detection_engineer.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/incident_responder/agent.py
+++ b/multi-agent/manager/sub_agents/incident_responder/agent.py
@@ -45,3 +45,11 @@ def get_agent(tools):
       tools=tools, # Use passed-in tools
   )
   return agent_instance # Only return the agent instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the Incident Responder agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/incident_responder.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/llm_judge/agent.py
+++ b/multi-agent/manager/sub_agents/llm_judge/agent.py
@@ -47,3 +47,11 @@ def get_agent(tools):
       """,
       tools=tools,
   )
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the LLM Judge agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/llm_judge.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/remote_assistant/agent.py
+++ b/multi-agent/manager/sub_agents/remote_assistant/agent.py
@@ -1,0 +1,39 @@
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+def get_agent(tools):
+  """
+  Returns a RemoteA2aAgent configured to talk to a local A2A service.
+
+  This assumes that an A2A service (e.g., soc_analyst_tier1 running as A2A)
+  is available at http://localhost:8001.
+  """
+  # The RemoteA2aAgent takes an 'agent_card' argument which can be a URL string
+  # pointing to the A2A service's card endpoint.
+  # The standard A2A implementation usually exposes the card at the root or /a2a.json
+  # We will point to the root URL of the service.
+  service_url = "http://localhost:8001/"
+
+  agent = RemoteA2aAgent(
+      name="remote_assistant",
+      agent_card=service_url,
+      # Remote agents don't use local tools directly, but we accept them for signature compatibility
+  )
+
+  # Add a description so the manager knows what this agent does.
+  # In a real scenario, this would be fetched from the remote card,
+  # but setting it here helps with initial planning before connection.
+  agent.description = "A remote assistant agent available via A2A interface. Can handle general queries or tasks delegated to the remote service."
+
+  return agent
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+    """
+    Creates an A2A app for this agent (proxying the remote one).
+    For a remote agent, this might just expose the same interface again.
+    """
+    from ...utils.a2a import get_a2a_app_from_config
+    # We can create a simple card for this proxy
+    # For now, we'll reuse the logic but we need a config file.
+    # Let's assume we don't need to expose the remote agent *as* an A2A service again immediately in this demo.
+    # But to satisfy the pattern, we could return a simple app.
+    raise NotImplementedError("Exposing a RemoteA2aAgent as an A2A service is not yet fully configured.")

--- a/multi-agent/manager/sub_agents/soc_analyst_tier1/agent.py
+++ b/multi-agent/manager/sub_agents/soc_analyst_tier1/agent.py
@@ -43,3 +43,11 @@ def get_agent(tools):
       tools=tools,
   )
   return agent_instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the SOC Analyst Tier 1 agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/soc_analyst_tier1.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/soc_analyst_tier2/agent.py
+++ b/multi-agent/manager/sub_agents/soc_analyst_tier2/agent.py
@@ -56,3 +56,11 @@ def get_agent(tools):
       tools=tools,
   )
   return agent_instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the SOC Analyst Tier 2 agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/soc_analyst_tier2.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/soc_analyst_tier3/agent.py
+++ b/multi-agent/manager/sub_agents/soc_analyst_tier3/agent.py
@@ -45,3 +45,11 @@ def get_agent(tools):
       tools=tools, # Use passed-in tools
   )
   return agent_instance # Only return the agent instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the SOC Analyst Tier 3 agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/soc_analyst_tier3.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/sub_agents/threat_hunter/agent.py
+++ b/multi-agent/manager/sub_agents/threat_hunter/agent.py
@@ -42,3 +42,11 @@ def get_agent(tools):
       tools=tools,
   )
   return agent_instance
+
+
+def get_a2a_app(tools, host="0.0.0.0", port=8000):
+  """Creates and returns an A2A application for the Threat Hunter agent."""
+  from ...utils.a2a import get_a2a_app_from_config
+  agent = get_agent(tools)
+  config_path = (Path(__file__).resolve().parent.parent.parent / "config/agents/threat_hunter.yaml").resolve()
+  return get_a2a_app_from_config(agent, str(config_path), host=host, port=port)

--- a/multi-agent/manager/utils/a2a.py
+++ b/multi-agent/manager/utils/a2a.py
@@ -1,0 +1,76 @@
+import os
+import yaml
+import logging
+from typing import Optional
+
+try:
+    from google.adk.a2a.utils.agent_to_a2a import to_a2a
+    from a2a.types import AgentCard, AgentSkill, AgentCapabilities
+except ImportError:
+    logging.warning("A2A library not found. A2A features will be unavailable.")
+    to_a2a = None
+    AgentCard = None
+    AgentSkill = None
+    AgentCapabilities = None
+
+def get_a2a_app_from_config(agent, yaml_config_path: str, host: str = "0.0.0.0", port: int = 8000, protocol: str = "http"):
+    """
+    Creates an A2A Starlette application for the given agent using a YAML configuration file.
+
+    Args:
+        agent: The initialized ADK Agent instance.
+        yaml_config_path: Path to the YAML configuration file defining the agent card properties.
+        host: The host for the A2A service (default: "0.0.0.0").
+        port: The port for the A2A service (default: 8000).
+        protocol: The protocol for the A2A service (default: "http").
+
+    Returns:
+        Starlette: The configured A2A application.
+    """
+    if not to_a2a:
+        raise ImportError("A2A library is required to use this feature.")
+
+    try:
+        with open(yaml_config_path, 'r') as f:
+            config = yaml.safe_load(f)
+    except FileNotFoundError:
+        logging.error(f"Configuration file not found at {yaml_config_path}")
+        raise
+
+    # Construct AgentSkill based on YAML configuration
+    # Combine expertise areas and delegation triggers as tags
+    tags = config.get('expertise_areas', []) + config.get('delegation_triggers', [])
+    # Filter duplicates and ensure strings
+    tags = list(set([str(tag) for tag in tags]))
+
+    skill = AgentSkill(
+        id=config.get('agent_name', agent.name),
+        name=config.get('display_name', agent.name),
+        description=config.get('description', agent.description or "No description provided"),
+        tags=tags,
+        input_modes=['text/plain'],
+        output_modes=['text/plain'],
+        examples=None
+    )
+
+    rpc_url = f"{protocol}://{host}:{port}"
+
+    card = AgentCard(
+        name=config.get('agent_name', agent.name),
+        description=config.get('description', agent.description or "No description provided"),
+        version="1.0.0",
+        skills=[skill],
+        capabilities=AgentCapabilities(),
+        url=rpc_url,
+        default_input_modes=['text/plain'],
+        default_output_modes=['text/plain'],
+        supports_authenticated_extended_card=False
+    )
+
+    return to_a2a(
+        agent=agent,
+        host=host,
+        port=port,
+        protocol=protocol,
+        agent_card=card
+    )

--- a/rules-bank/multi_agent/a2a_agent_cards_reference.md
+++ b/rules-bank/multi_agent/a2a_agent_cards_reference.md
@@ -1,0 +1,103 @@
+# A2A Agent Cards Reference
+
+This document serves as a reference for the Agent-to-Agent (A2A) Cards used in the ADK multi-agent system. These cards, implemented as YAML configuration files, define the capabilities, expertise, and tool access for each specialized agent in the system, enabling the SOC Manager agent to intelligently delegate tasks.
+
+## Purpose
+
+The A2A Agent Cards are the foundation of the [Configuration-Based Delegation System](./configuration_based_delegation.md). They allow the SOC Manager to "know" its team members' capabilities without hardcoding this logic into the manager's persona or prompt. This makes the system more modular, maintainable, and easier to expand.
+
+## Location
+
+The configuration files are located in:
+`multi-agent/manager/config/agents/`
+
+## Configuration Structure
+
+Each agent card is a YAML file (e.g., `soc_analyst_tier1.yaml`) containing the following sections:
+
+### 1. Identity & Description
+Defines who the agent is and its high-level role.
+
+```yaml
+agent_name: soc_analyst_tier1        # Unique identifier (snake_case)
+display_name: "SOC Analyst Tier 1"   # Human-readable name
+description: "Initial alert triage and basic IOC enrichment specialist"
+```
+
+### 2. Expertise Areas
+A list of specific skills or domains the agent specializes in. The manager uses these keywords to match tasks to agents.
+
+```yaml
+expertise_areas:
+  - alert_triage
+  - basic_ioc_enrichment
+  - phishing_email_analysis
+```
+
+### 3. MCP Servers (Tools)
+Lists the Model Context Protocol (MCP) servers the agent has access to. This defines the agent's "toolbox."
+
+```yaml
+mcp_servers:
+  - name: secops-mcp
+    description: "SIEM operations"
+  - name: gti-mcp
+    description: "Threat Intelligence"
+```
+
+### 4. Delegation Triggers
+Keywords or phrases that, when present in a user request or manager's intent, strongly suggest this agent should handle the task.
+
+```yaml
+delegation_triggers:
+  - "triage"
+  - "alert"
+  - "suspicious login"
+```
+
+### 5. Capabilities
+Operational constraints and relationships, such as escalation paths and alert severity handling.
+
+```yaml
+capabilities:
+  can_escalate_to:
+    - soc_analyst_tier2
+    - incident_responder
+  handles_alert_severity:
+    - low
+    - medium
+```
+
+## Configured Agents
+
+The following agents are currently configured in the system:
+
+*   **SOC Manager (`manager.yaml`):** Orchestrates operations, delegates tasks, and writes reports.
+*   **SOC Analyst Tier 1 (`soc_analyst_tier1.yaml`):** Handles initial triage, basic enrichment, and low/medium severity alerts.
+*   **SOC Analyst Tier 2 (`soc_analyst_tier2.yaml`):** Performs deep investigations, manages SOAR cases, and handles medium/high severity alerts.
+*   **SOC Analyst Tier 3 (`soc_analyst_tier3.yaml`):** Manages critical incidents, complex malware analysis, and high-severity escalations.
+*   **CTI Researcher (`cti_researcher.yaml`):** Conducts threat intelligence research, actor profiling, and campaign analysis.
+*   **Threat Hunter (`threat_hunter.yaml`):** Executes proactive, hypothesis-driven threat hunts.
+*   **Incident Responder (`incident_responder.yaml`):** Focuses on containment, eradication, and recovery phases of incident response.
+*   **Detection Engineer (`detection_engineer.yaml`):** Develops and tunes detection rules and manages detection-as-code workflows.
+*   **LLM Judge (`llm_judge.yaml`):** Evaluates runbook executions and agent performance against defined rubrics.
+
+## How to Add or Modify Agent Cards
+
+### Modifying an Existing Agent
+1.  Navigate to `multi-agent/manager/config/agents/`.
+2.  Open the relevant YAML file.
+3.  Update fields (e.g., add a new `delegation_trigger` or `expertise_area`).
+4.  Save the file. The changes will take effect the next time the manager loads its configuration.
+
+### Adding a New Agent
+1.  Create a new YAML file in `multi-agent/manager/config/agents/` (e.g., `forensics_specialist.yaml`).
+2.  Fill in the required fields following the structure above.
+3.  Ensure the `agent_name` is unique.
+4.  (Optional) Update `tool_agent_mapping.yaml` if specific tool-based routing rules are needed (see [Configuration-Based Delegation](./configuration_based_delegation.md)).
+
+## Best Practices
+
+*   **Specificity:** Make `delegation_triggers` specific enough to avoid ambiguity but broad enough to capture relevant variations.
+*   **Overlap:** Avoid significant overlap in `delegation_triggers` between agents unless intended for fallback or collaborative scenarios.
+*   **Consistency:** Keep `agent_name` consistent with the Python module names in `multi-agent/manager/sub_agents/` if manual instantiation is used alongside configuration loading.


### PR DESCRIPTION
This PR creates the Agent Cards (YAML configuration files) for the multi-agent system as part of the A2A (Agent-to-Agent) deployment mode. These files define the capabilities, tools, and delegation triggers for each agent, facilitating the configuration-based delegation system.

---
*PR created automatically by Jules for task [7324429452081830171](https://jules.google.com/task/7324429452081830171) started by @dandye*