### PR TITLE
Add 80k context cache configuration to manager app

### DIFF
--- a/multi-agent/manager/agent.py
+++ b/multi-agent/manager/agent.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 
 from google.adk.agents import Agent
+from google.adk.apps.app import App
+from google.adk.agents.context_cache_config import ContextCacheConfig
 
 from .sub_agents.soc_analyst_tier1 import agent as soc_analyst_tier1_agent_module
 from .sub_agents.soc_analyst_tier2 import agent as soc_analyst_tier2_agent_module
@@ -116,4 +118,10 @@ root_agent = Agent(
         write_report,
         read_file_content,
     ],
+)
+
+app = App(
+    name="manager_app",
+    root_agent=root_agent,
+    context_cache_config=ContextCacheConfig(min_tokens=80000)
 )


### PR DESCRIPTION
Implemented the "skills with 80k to provide context" feature by adding `ContextCacheConfig` with `min_tokens=80000` to the `manager` app definition in `multi-agent/manager/agent.py`. This uses the `google-adk` library's `App` and `ContextCacheConfig` classes to apply caching configuration to the agent hierarchy. Verified the configuration by importing the `app` object and inspecting its properties.

---
*PR created automatically by Jules for task [16705839739845618420](https://jules.google.com/task/16705839739845618420) started by @dandye*