### PR TITLE
Add OKF v0.2 frontmatter to markdown content files

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: GitHub Workflows
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T00:15:29-05:00
+---
+
 # GitHub Workflows
 
 This directory contains GitHub Actions workflows for the ADK Runbooks project.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: GEMINI.md
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T00:15:29-05:00
+---
+
 # GEMINI.md
 
 This file provides guidance to Gemini Code when working with code in this repository.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: ADK Runbooks
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T00:15:29-05:00
+---
+
 # ADK Runbooks
 
 A comprehensive multi-agent cybersecurity operations system built on Google's Agent Development Kit (ADK). This project provides specialized AI agents that collaborate to handle security operations tasks including incident response, threat hunting, detection engineering, and security operations center (SOC) activities.

--- a/SETUP_GEMINI.md
+++ b/SETUP_GEMINI.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Project Setup Guide
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T00:15:29-05:00
+---
+
 ![Screenshot 2025-05-18 at 4 16 04 PM](https://github.com/user-attachments/assets/338a92af-1721-4b6f-9c9c-c451c9581129)
 
 # Project Setup Guide

--- a/dac-agent/README.md
+++ b/dac-agent/README.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Detection-as-Code (DAC) Agent
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # Detection-as-Code (DAC) Agent
 
 An autonomous agent for Detection-as-Code rule tuning based on SOAR case feedback and analyst input.

--- a/dac-agent/reports/DAC_Workflow_Report_20250618_233850.md
+++ b/dac-agent/reports/DAC_Workflow_Report_20250618_233850.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: Detection-as-Code Workflow Execution Report
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # Detection-as-Code Workflow Execution Report
 
 **Generated**: 20250618_233850

--- a/dac-agent/reports/DAC_Workflow_Report_20250618_234158.md
+++ b/dac-agent/reports/DAC_Workflow_Report_20250618_234158.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: Detection-as-Code Workflow Execution Report
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # Detection-as-Code Workflow Execution Report
 
 **Generated**: 20250618_234158

--- a/dac-agent/reports/DAC_Workflow_Report_20250618_234330.md
+++ b/dac-agent/reports/DAC_Workflow_Report_20250618_234330.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: Detection-as-Code Workflow Execution Report
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # Detection-as-Code Workflow Execution Report
 
 **Generated**: 20250618_234330

--- a/multi-agent/README.md
+++ b/multi-agent/README.md
@@ -1,0 +1,8 @@
+---
+type: Reference
+title: Readme
+generated:
+  by: human:dandye
+  at: 2025-05-31T19:50:19-04:00
+---
+

--- a/multi-agent/reports/SOAR_Case_2955_Malware_Incident_Report_20250615_010034.md
+++ b/multi-agent/reports/SOAR_Case_2955_Malware_Incident_Report_20250615_010034.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: "Malware Incident Report: SOAR Case 2955"
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # Malware Incident Report: SOAR Case 2955
 
 **Case ID:** SOAR_CASE_2955

--- a/reports/IOC_Search_Report_campaign--3ac8d482-a08f-549a-9b5d-7b6435471a94_20250518_162641.md
+++ b/reports/IOC_Search_Report_campaign--3ac8d482-a08f-549a-9b5d-7b6435471a94_20250518_162641.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: "IOC Search Report: campaign--3ac8d482-a08f-549a-9b5d-7b6435471a94"
+generated:
+  by: human:dandye
+  at: 2025-09-08T12:02:00-04:00
+---
+
 # IOC Search Report: campaign--3ac8d482-a08f-549a-9b5d-7b6435471a94
 
 **Date:** 2025-05-18 16:26:41

--- a/reports/SOAR Case Report - 2396_20250517_191055.md
+++ b/reports/SOAR Case Report - 2396_20250517_191055.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: "SOAR Case Report: 2396"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 ## SOAR Case Report: 2396
 
 **Case Summary:**

--- a/reports/UNC5112_DARKGATE_Campaign_Report_20250517_234400_20250517_234555.md
+++ b/reports/UNC5112_DARKGATE_Campaign_Report_20250517_234400_20250517_234555.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: "Campaign Report: UNC5112 Distributes DARKGATE"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Campaign Report: UNC5112 Distributes DARKGATE
 
 **Campaign ID:** `campaign--4085772a-45c3-5a8a-b793-c3fbc7fed977`

--- a/reports/current_time_20250517_184319.md
+++ b/reports/current_time_20250517_184319.md
@@ -1,1 +1,9 @@
+---
+type: Report
+title: "Current Time Check (2025-05-17 18:43:19)"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 the current time is... 20250517_184317

--- a/reports/report1.md
+++ b/reports/report1.md
@@ -1,3 +1,11 @@
+---
+type: Report
+title: "Incident Report: Case 2451 - SOAR/Chronicle Discrepancy and File IoC Investigation"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 user: update that report with the MCP Tools that were used
 [soc_analyst_tier2]: ## Incident Report: Case 2451 - SOAR/Chronicle Discrepancy and File IoC Investigation
 

--- a/rules-bank/agent_workflow_references.md
+++ b/rules-bank/agent_workflow_references.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Agent Workflow References
+generated:
+  by: human:dandye
+  at: 2025-07-30T22:29:48-04:00
+---
+
 # Agent Workflow References
 
 This document contains references to blog posts and other resources that demonstrate how to organize agents into workflows.

--- a/rules-bank/ai/ai_decision_review_guidelines.md
+++ b/rules-bank/ai/ai_decision_review_guidelines.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: AI Decision Review Guidelines
+generated:
+  by: human:dandye
+  at: 2025-05-31T13:54:55-04:00
+---
+
 # AI Decision Review Guidelines
 
 This document outlines the procedures for human analysts to review AI-driven alert triage and investigation decisions. It also defines a standardized feedback format to support the "Identification" and "Learning" phases of the PICERL AI Performance Framework, specifically targeting "Feedback Loop Metrics" and "Escalation-to-Accuracy Ratio."

--- a/rules-bank/ai/ai_explainability_standards.md
+++ b/rules-bank/ai/ai_explainability_standards.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: AI Explainability Standards
+generated:
+  by: human:dandye
+  at: 2025-05-31T13:54:55-04:00
+---
+
 # AI Explainability Standards
 
 This document defines standards for AI agent explanations to improve clarity, trustworthiness, and the speed at which human analysts can understand AI-driven decisions. This supports the "Explainability Time/Score" metric within the PICERL AI Performance Framework ("Identification" and "Learning" phases).

--- a/rules-bank/ai/ai_performance_framework_picerl.md
+++ b/rules-bank/ai/ai_performance_framework_picerl.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: "AI Performance Framework: PICERL Index"
+generated:
+  by: human:dandye
+  at: 2025-05-31T13:54:55-04:00
+---
+
 # AI Performance Framework: PICERL Index
 
 This document introduces the PICERL Index (Preparation, Identification, Containment, Eradication, Recovery, and Learning) as a framework for measuring and improving the effectiveness of AI agents in Security Operations. It outlines how various documents within this `rules-bank` support each phase and lists key metrics for AI agent performance.

--- a/rules-bank/ai/ai_performance_logging_requirements.md
+++ b/rules-bank/ai/ai_performance_logging_requirements.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: AI Performance Logging Requirements
+generated:
+  by: human:dandye
+  at: 2025-05-31T13:54:55-04:00
+---
+
 # AI Performance Logging Requirements
 
 This document specifies the key data points that AI agents must log for significant actions and decisions. Consistent and comprehensive logging is crucial for calculating PICERL-related metrics, troubleshooting AI behavior, and facilitating continuous improvement.

--- a/rules-bank/analytical_query_patterns.md
+++ b/rules-bank/analytical_query_patterns.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Analytical Query Patterns for AI Agents
+generated:
+  by: human:dandye
+  at: 2025-06-02T12:14:04-04:00
+---
+
 # Analytical Query Patterns for AI Agents
 
 This document serves as a "cookbook" for AI agents, providing templates for common analytical questions and their corresponding query structures for key security tools, with a primary focus on Chronicle SIEM (UDM queries via `secops-mcp - search_security_events`).

--- a/rules-bank/atomic_runbooks/domain/rb_domain_get_gti_report.md
+++ b/rules-bank/atomic_runbooks/domain/rb_domain_get_gti_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get Domain Reputation from GTI"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get Domain Reputation from GTI
 
 **ID:** `RB-ATOM-DOMAIN-001`

--- a/rules-bank/atomic_runbooks/domain/rb_domain_get_secops_threat_intel.md
+++ b/rules-bank/atomic_runbooks/domain/rb_domain_get_secops_threat_intel.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get Domain Threat Intel via SecOps MCP"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get Domain Threat Intel via SecOps MCP
 
 **ID:** `RB-ATOM-DOMAIN-002`

--- a/rules-bank/atomic_runbooks/domain/rb_domain_lookup_entity_chronicle.md
+++ b/rules-bank/atomic_runbooks/domain/rb_domain_lookup_entity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Lookup Domain Entity Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Lookup Domain Entity Activity in Chronicle
 
 **ID:** `RB-ATOM-DOMAIN-003`

--- a/rules-bank/atomic_runbooks/domain/rb_domain_search_dns_chronicle.md
+++ b/rules-bank/atomic_runbooks/domain/rb_domain_search_dns_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search Domain DNS Queries in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search Domain DNS Queries in Chronicle
 
 **ID:** `RB-ATOM-DOMAIN-004`

--- a/rules-bank/atomic_runbooks/domain/rb_domain_search_network_traffic_chronicle.md
+++ b/rules-bank/atomic_runbooks/domain/rb_domain_search_network_traffic_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search Domain-Related Network Traffic in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search Domain-Related Network Traffic in Chronicle
 
 **ID:** `RB-ATOM-DOMAIN-005`

--- a/rules-bank/atomic_runbooks/hash/rb_hash_get_gti_report.md
+++ b/rules-bank/atomic_runbooks/hash/rb_hash_get_gti_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get File Hash Reputation from GTI"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get File Hash Reputation from GTI
 
 **ID:** `RB-ATOM-HASH-001`

--- a/rules-bank/atomic_runbooks/hash/rb_hash_get_secops_threat_intel.md
+++ b/rules-bank/atomic_runbooks/hash/rb_hash_get_secops_threat_intel.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get File Hash Threat Intel via SecOps MCP"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get File Hash Threat Intel via SecOps MCP
 
 **ID:** `RB-ATOM-HASH-002`

--- a/rules-bank/atomic_runbooks/hash/rb_hash_lookup_entity_chronicle.md
+++ b/rules-bank/atomic_runbooks/hash/rb_hash_lookup_entity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Lookup File Hash Entity Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Lookup File Hash Entity Activity in Chronicle
 
 **ID:** `RB-ATOM-HASH-003`

--- a/rules-bank/atomic_runbooks/hash/rb_hash_search_process_events_chronicle.md
+++ b/rules-bank/atomic_runbooks/hash/rb_hash_search_process_events_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search File Hash Process Events in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search File Hash Process Events in Chronicle
 
 **ID:** `RB-ATOM-HASH-004`

--- a/rules-bank/atomic_runbooks/ip_address/rb_ip_get_gti_report.md
+++ b/rules-bank/atomic_runbooks/ip_address/rb_ip_get_gti_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get IP Address Reputation from GTI"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get IP Address Reputation from GTI
 
 **ID:** `RB-ATOM-IP-001`

--- a/rules-bank/atomic_runbooks/ip_address/rb_ip_get_secops_threat_intel.md
+++ b/rules-bank/atomic_runbooks/ip_address/rb_ip_get_secops_threat_intel.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get IP Address Threat Intel via SecOps MCP"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get IP Address Threat Intel via SecOps MCP
 
 **ID:** `RB-ATOM-IP-002`

--- a/rules-bank/atomic_runbooks/ip_address/rb_ip_lookup_entity_chronicle.md
+++ b/rules-bank/atomic_runbooks/ip_address/rb_ip_lookup_entity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Lookup IP Entity Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Lookup IP Entity Activity in Chronicle
 
 **ID:** `RB-ATOM-IP-003`

--- a/rules-bank/atomic_runbooks/ip_address/rb_ip_search_network_traffic_chronicle.md
+++ b/rules-bank/atomic_runbooks/ip_address/rb_ip_search_network_traffic_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search IP Network Traffic in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search IP Network Traffic in Chronicle
 
 **ID:** `RB-ATOM-IP-004`

--- a/rules-bank/atomic_runbooks/url/rb_url_get_gti_report.md
+++ b/rules-bank/atomic_runbooks/url/rb_url_get_gti_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get URL Reputation from GTI"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get URL Reputation from GTI
 
 **ID:** `RB-ATOM-URL-001`

--- a/rules-bank/atomic_runbooks/url/rb_url_get_secops_threat_intel.md
+++ b/rules-bank/atomic_runbooks/url/rb_url_get_secops_threat_intel.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Get URL Threat Intel via SecOps MCP"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Get URL Threat Intel via SecOps MCP
 
 **ID:** `RB-ATOM-URL-002`

--- a/rules-bank/atomic_runbooks/url/rb_url_search_chronicle.md
+++ b/rules-bank/atomic_runbooks/url/rb_url_search_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search URL Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search URL Activity in Chronicle
 
 **ID:** `RB-ATOM-URL-003`

--- a/rules-bank/atomic_runbooks/user/rb_user_lookup_entity_chronicle.md
+++ b/rules-bank/atomic_runbooks/user/rb_user_lookup_entity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Lookup User Entity Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Lookup User Entity Activity in Chronicle
 
 **ID:** `RB-ATOM-USER-001`

--- a/rules-bank/atomic_runbooks/user/rb_user_search_login_activity_chronicle.md
+++ b/rules-bank/atomic_runbooks/user/rb_user_search_login_activity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search User Login Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search User Login Activity in Chronicle
 
 **ID:** `RB-ATOM-USER-002`

--- a/rules-bank/atomic_runbooks/user/rb_user_search_process_activity_chronicle.md
+++ b/rules-bank/atomic_runbooks/user/rb_user_search_process_activity_chronicle.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Atomic Runbook: Search User Process Activity in Chronicle"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: Search User Process Activity in Chronicle
 
 **ID:** `RB-ATOM-USER-003`

--- a/rules-bank/automated_response_playbook_criteria.md
+++ b/rules-bank/automated_response_playbook_criteria.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Automated Response Playbook Criteria
+generated:
+  by: human:dandye
+  at: 2025-05-31T19:50:19-04:00
+---
+
 # Automated Response Playbook Criteria
 
 This document outlines criteria for triggering automated response actions by AI agents or SOAR playbooks. It details pre-conditions, safety checks, and rollback procedures to ensure automated responses are executed safely and effectively. This expands on the original `approved_remediations.md`.

--- a/rules-bank/coding_conventions.md
+++ b/rules-bank/coding_conventions.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Coding Conventions
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Coding Conventions
 
 This document outlines the coding conventions for the Python code within the `google-mcp-security` project. The project aims to follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).

--- a/rules-bank/data_normalization_map.md
+++ b/rules-bank/data_normalization_map.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Data Normalization Map
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Data Normalization Map
 
 This document provides mappings for common data fields across various log sources and tools to a standardized (e.g., UDM - Unified Data Model) or common internal representation. This helps AI agents correlate data and construct queries effectively.

--- a/rules-bank/detection_improvement_process.md
+++ b/rules-bank/detection_improvement_process.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Detection Improvement Process for AI Agents
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Detection Improvement Process for AI Agents
 
 This document outlines the process for AI agents to identify, document, and report potential detection gaps. This formalizes the "Detection Gaps Identification" and "Feedback to Detection Engineering" loop described in the "Blueprint for AI Agents in Cybersecurity."

--- a/rules-bank/detection_strategy.md
+++ b/rules-bank/detection_strategy.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Detection Strategy Overview
+generated:
+  by: human:dandye
+  at: 2025-05-31T19:50:19-04:00
+---
+
 # Detection Strategy Overview
 
 This document outlines the organization's high-level strategy for security detection development, key platforms, focus areas, and how AI agents contribute to and are measured within this strategy.

--- a/rules-bank/detection_use_cases/duc_template_package.md
+++ b/rules-bank/detection_use_cases/duc_template_package.md
@@ -1,3 +1,11 @@
+---
+type: Template
+title: "Detection Use-Case Package: [USE_CASE_NAME_Placeholder]"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Detection Use-Case Package: [USE_CASE_NAME_Placeholder]
 
 ## 1. Use-Case Overview

--- a/rules-bank/indicator_handling_protocols.md
+++ b/rules-bank/indicator_handling_protocols.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Indicator Handling Protocols
+generated:
+  by: human:dandye
+  at: 2025-05-31T19:50:19-04:00
+---
+
 # Indicator Handling Protocols
 
 This document outlines standardized initial investigation steps, preferred tools, and key questions for different types of indicators. It is designed to guide both human analysts and AI agents in the initial phase of indicator-based investigation.

--- a/rules-bank/log_source_overview.md
+++ b/rules-bank/log_source_overview.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Log Source Overview
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Log Source Overview
 
 This document identifies critical log sources for security monitoring, their primary ingestion methods, typical retention periods, and how AI agents can assist in monitoring their health and coverage.

--- a/rules-bank/mcp_tool_best_practices.md
+++ b/rules-bank/mcp_tool_best_practices.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: MCP Tool Best Practices & Usage Guide
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # MCP Tool Best Practices & Usage Guide
 
 This document provides best practices, tips, and important considerations for using Model Context Protocol (MCP) tools, especially those interacting with security platforms like Chronicle SIEM and Google Threat Intelligence (GTI).

--- a/rules-bank/multi_agent/README.md
+++ b/rules-bank/multi_agent/README.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Multi-Agent Configuration System
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:05:33-04:00
+---
+
 # Multi-Agent Configuration System
 
 This directory contains documentation and configuration specifications for the ADK Runbooks multi-agent system's intelligent delegation framework.

--- a/rules-bank/multi_agent/agent_workflow_references.md
+++ b/rules-bank/multi_agent/agent_workflow_references.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Agent Workflow References
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Agent Workflow References
 
 This document contains references to blog posts and other resources that demonstrate how to organize agents into workflows.

--- a/rules-bank/multi_agent/config_quick_reference.md
+++ b/rules-bank/multi_agent/config_quick_reference.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Configuration System Quick Reference
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:04:23-04:00
+---
+
 # Configuration System Quick Reference
 
 ## File Locations

--- a/rules-bank/multi_agent/configuration_based_delegation.md
+++ b/rules-bank/multi_agent/configuration_based_delegation.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Configuration-Based Delegation System
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:04:23-04:00
+---
+
 # Configuration-Based Delegation System
 
 ## Overview

--- a/rules-bank/multi_agent_overview.md
+++ b/rules-bank/multi_agent_overview.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Multi-Agent Systems in ADK
+generated:
+  by: human:dandye
+  at: 2025-06-18T22:23:28-04:00
+---
+
 # Multi-Agent Systems in ADK
 
 This document provides an overview of creating and using multi-agent systems within the Agent Development Kit (ADK). Specialized security agents collaborate to handle complex cybersecurity tasks, each focusing on their area of expertise.

--- a/rules-bank/personas/ciso.md
+++ b/rules-bank/personas/ciso.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Chief Information Security Officer (CISO)"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Chief Information Security Officer (CISO)
 
 ## Overview

--- a/rules-bank/personas/compliance_manager.md
+++ b/rules-bank/personas/compliance_manager.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Compliance Manager"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Compliance Manager
 
 ## Overview

--- a/rules-bank/personas/cti_researcher.md
+++ b/rules-bank/personas/cti_researcher.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Cyber Threat Intelligence (CTI) Researcher"
+generated:
+  by: human:dandye
+  at: 2025-06-02T12:14:04-04:00
+---
+
 # Persona: Cyber Threat Intelligence (CTI) Researcher
 
 ## Overview

--- a/rules-bank/personas/detection_engineer.md
+++ b/rules-bank/personas/detection_engineer.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Detection Engineer"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Detection Engineer
 
 ## Overview

--- a/rules-bank/personas/incident_responder.md
+++ b/rules-bank/personas/incident_responder.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Incident Responder (IR)"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Incident Responder (IR)
 
 ## Overview

--- a/rules-bank/personas/llm_judge.md
+++ b/rules-bank/personas/llm_judge.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: LLM Judge Persona
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # LLM Judge Persona
 
 ## Role Description

--- a/rules-bank/personas/personas.md
+++ b/rules-bank/personas/personas.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Security Personas
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Security Personas
 
 This directory contains descriptions of various security roles, outlining their typical responsibilities, skills, commonly used tools (especially within the MCP context), and relevant runbooks.

--- a/rules-bank/personas/red_team.md
+++ b/rules-bank/personas/red_team.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Red Team Member"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Red Team Member
 
 ## Overview

--- a/rules-bank/personas/security_engineer.md
+++ b/rules-bank/personas/security_engineer.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Security Engineer"
+generated:
+  by: human:dandye
+  at: 2025-06-02T12:14:04-04:00
+---
+
 # Persona: Security Engineer
 
 ## Overview

--- a/rules-bank/personas/soc_analyst_tier_1.md
+++ b/rules-bank/personas/soc_analyst_tier_1.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Tier 1 SOC Analyst"
+generated:
+  by: human:dandye
+  at: 2025-05-18T15:35:55-04:00
+---
+
 # Persona: Tier 1 SOC Analyst
 
 ## Overview

--- a/rules-bank/personas/soc_analyst_tier_2.md
+++ b/rules-bank/personas/soc_analyst_tier_2.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Tier 2 SOC Analyst"
+generated:
+  by: human:dandye
+  at: 2025-05-18T15:35:55-04:00
+---
+
 # Persona: Tier 2 SOC Analyst
 
 ## Overview

--- a/rules-bank/personas/soc_analyst_tier_3.md
+++ b/rules-bank/personas/soc_analyst_tier_3.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Tier 3 SOC Analyst"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Tier 3 SOC Analyst
 
 ## Overview

--- a/rules-bank/personas/soc_manager.md
+++ b/rules-bank/personas/soc_manager.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: SOC Manager"
+generated:
+  by: human:dandye
+  at: 2025-05-19T13:39:50-04:00
+---
+
 # Persona: SOC Manager
 
 ## Overview

--- a/rules-bank/personas/threat_hunter.md
+++ b/rules-bank/personas/threat_hunter.md
@@ -1,3 +1,11 @@
+---
+type: Persona
+title: "Persona: Threat Hunter"
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Persona: Threat Hunter
 
 ## Overview

--- a/rules-bank/project_plan.md
+++ b/rules-bank/project_plan.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: "Project Plan: Enhance LLM Agent Context"
+generated:
+  by: human:dandye
+  at: 2026-03-30T21:16:55-04:00
+---
+
 # Project Plan: Enhance LLM Agent Context
 
 **Project Goal:** To create a comprehensive set of context files within the rules-bank directory, improving the LLM Agent's understanding of the environment, tools, policies, and relevant threats.

--- a/rules-bank/readme.md
+++ b/rules-bank/readme.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Rules Bank Directory Overview
+generated:
+  by: human:dandye
+  at: 2025-05-18T18:48:26-04:00
+---
+
 # Rules Bank Directory Overview
 
 This directory contains configuration files and documentation to provide context and guidance for LLM Agents operating within this security environment.

--- a/rules-bank/reporting_templates.md
+++ b/rules-bank/reporting_templates.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Reporting Templates & Guidelines
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Reporting Templates & Guidelines
 
 This file outlines standard formats and required elements for common reports generated during security operations.

--- a/rules-bank/run_books/advanced_threat_hunting.md
+++ b/rules-bank/run_books/advanced_threat_hunting.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Advanced Threat Hunting (Hypothesis-Driven) Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Advanced Threat Hunting (Hypothesis-Driven) Runbook
 
 ## Objective

--- a/rules-bank/run_books/alert_report.md
+++ b/rules-bank/run_books/alert_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Alert Investigation Summary Report Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Alert Investigation Summary Report Runbook
 
 ## Objective

--- a/rules-bank/run_books/apt_threat_hunt.md
+++ b/rules-bank/run_books/apt_threat_hunt.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: APT Threat Hunt"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: APT Threat Hunt
 
 ## Objective

--- a/rules-bank/run_books/basic_endpoint_triage_isolation.md
+++ b/rules-bank/run_books/basic_endpoint_triage_isolation.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Basic Endpoint Triage & Isolation Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Basic Endpoint Triage & Isolation Runbook
 
 ## Objective

--- a/rules-bank/run_books/basic_ioc_enrichment.md
+++ b/rules-bank/run_books/basic_ioc_enrichment.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Basic IOC Enrichment Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Basic IOC Enrichment Runbook
 
 ## Objective

--- a/rules-bank/run_books/case_event_timeline_and_process_analysis.md
+++ b/rules-bank/run_books/case_event_timeline_and_process_analysis.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Case Event Timeline & Process Analysis Workflow
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Case Event Timeline & Process Analysis Workflow
 
 Objective: Generate a detailed timeline of events for a specific SOAR case (`${CASE_ID}`), including the **full process execution chain** leading to the alerted activity. Classify relevant processes as legitimate, LOLBIN, or malicious using GTI enrichment. Optionally enrich with MITRE TACTICs and generate a markdown report summarizing the findings. Optionally convert the report to PDF and attempt to attach it to the SOAR case.

--- a/rules-bank/run_books/case_report.md
+++ b/rules-bank/run_books/case_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Generate Case Investigation Report"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Generate Case Investigation Report
 
 ## Objective

--- a/rules-bank/run_books/close_duplicate_or_similar_cases.md
+++ b/rules-bank/run_books/close_duplicate_or_similar_cases.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Close duplicate/similar Cases Workflow
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Close duplicate/similar Cases Workflow
 
 ```{mermaid}

--- a/rules-bank/run_books/cloud_vulnerability_triage_and_contextualization.md
+++ b/rules-bank/run_books/cloud_vulnerability_triage_and_contextualization.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Cloud Vulnerability Triage & Contextualization
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Cloud Vulnerability Triage & Contextualization
 
 Objective: Triage top critical/high SCC vulnerability findings for a given project (`${PROJECT_ID}`). Enrich the CVEs with GTI, check for related exploitation activity in SIEM, and summarize findings for remediation prioritization, potentially adding context to a SOAR case.

--- a/rules-bank/run_books/common_steps/check_duplicate_cases.md
+++ b/rules-bank/run_books/common_steps/check_duplicate_cases.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Check for Duplicate/Similar SOAR Cases"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Check for Duplicate/Similar SOAR Cases
 
 ## Objective

--- a/rules-bank/run_books/common_steps/close_soar_artifact.md
+++ b/rules-bank/run_books/common_steps/close_soar_artifact.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Close SOAR Case or Alert"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Close SOAR Case or Alert
 
 ## Objective

--- a/rules-bank/run_books/common_steps/confirm_action.md
+++ b/rules-bank/run_books/common_steps/confirm_action.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Confirm Action with User"
+generated:
+  by: human:dandye
+  at: 2025-05-19T16:11:00-04:00
+---
+
 # Common Step: Confirm Action with User
 
 ## Objective

--- a/rules-bank/run_books/common_steps/correlate_ioc_with_alerts_cases.md
+++ b/rules-bank/run_books/common_steps/correlate_ioc_with_alerts_cases.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Correlate IOC with SIEM Alerts & SOAR Cases"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Correlate IOC with SIEM Alerts & SOAR Cases
 
 ## Objective

--- a/rules-bank/run_books/common_steps/document_in_soar.md
+++ b/rules-bank/run_books/common_steps/document_in_soar.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Document Findings/Actions in SOAR Case"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Document Findings/Actions in SOAR Case
 
 ## Objective

--- a/rules-bank/run_books/common_steps/enrich_ioc.md
+++ b/rules-bank/run_books/common_steps/enrich_ioc.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Enrich IOC (GTI + SIEM)"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Enrich IOC (GTI + SIEM)
 
 ## Objective

--- a/rules-bank/run_books/common_steps/find_relevant_soar_case.md
+++ b/rules-bank/run_books/common_steps/find_relevant_soar_case.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Find Relevant SOAR Case"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Find Relevant SOAR Case
 
 ## Objective

--- a/rules-bank/run_books/common_steps/generate_report_file.md
+++ b/rules-bank/run_books/common_steps/generate_report_file.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Generate Report File"
+generated:
+  by: human:dandye
+  at: 2025-05-19T13:12:49-04:00
+---
+
 # Common Step: Generate Report File
 
 ## Objective

--- a/rules-bank/run_books/common_steps/pivot_on_ioc_gti.md
+++ b/rules-bank/run_books/common_steps/pivot_on_ioc_gti.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Common Step: Pivot on IOC using GTI Relationships"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Common Step: Pivot on IOC using GTI Relationships
 
 ## Objective

--- a/rules-bank/run_books/compare_gti_collection_to_iocs_and_events.md
+++ b/rules-bank/run_books/compare_gti_collection_to_iocs_and_events.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Compare GTI Collection to IoCs, Events in SecOps
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Compare GTI Collection to IoCs, Events in SecOps
 
 From a GTI Collection (could be a Private Collection as well), search the past 3 days for any UDM events containing:

--- a/rules-bank/run_books/create_an_investigation_report.md
+++ b/rules-bank/run_books/create_an_investigation_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Create Investigation Report"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Create Investigation Report
 
 ## Objective

--- a/rules-bank/run_books/data_lake_queries.md
+++ b/rules-bank/run_books/data_lake_queries.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Data Lake Queries"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Data Lake Queries
 
 ## Objective

--- a/rules-bank/run_books/deep_dive_ioc_analysis.md
+++ b/rules-bank/run_books/deep_dive_ioc_analysis.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Deep Dive IOC Analysis Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Deep Dive IOC Analysis Runbook
 
 ## Objective

--- a/rules-bank/run_books/demo_soc_t2_soar_runbook.md
+++ b/rules-bank/run_books/demo_soc_t2_soar_runbook.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: SOC Analyst Tier 2 Demo Runbook (SOAR Focus)
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # SOC Analyst Tier 2 Demo Runbook (SOAR Focus)
 
 As a SOC Analyst Tier 2, your work revolves around the SOAR platform.

--- a/rules-bank/run_books/detection_as_code_rule_tuning.md
+++ b/rules-bank/run_books/detection_as_code_rule_tuning.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Detection-as-Code Rule Tuning Workflow
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Detection-as-Code Rule Tuning Workflow
 
 ## Overview

--- a/rules-bank/run_books/detection_as_code_workflows.md
+++ b/rules-bank/run_books/detection_as_code_workflows.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Detection-as-Code Workflow (Placeholder)"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Detection-as-Code Workflow (Placeholder)
 
 ## Objective

--- a/rules-bank/run_books/detection_report.md
+++ b/rules-bank/run_books/detection_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Generate Detection Report"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Generate Detection Report
 
 ## Objective

--- a/rules-bank/run_books/detection_rule_validation_tuning.md
+++ b/rules-bank/run_books/detection_rule_validation_tuning.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Detection Rule Validation & Tuning Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Detection Rule Validation & Tuning Runbook
 
 ## Objective

--- a/rules-bank/run_books/group_cases.md
+++ b/rules-bank/run_books/group_cases.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Group Cases Workflow
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Group Cases Workflow
 
 From the last 5 cases, examine the underlying entities in the alerts and events and group the cases logically. Then, extract details from each case in each cluster to build a high fidelity understanding of each cases' disposition and involved entities. Make sure you have an in depth understanding of each case before moving on to the next step.

--- a/rules-bank/run_books/group_cases_v2.md
+++ b/rules-bank/run_books/group_cases_v2.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Group Cases v2"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Group Cases v2
 
 ## Objective

--- a/rules-bank/run_books/guided_ttp_hunt_credential_access.md
+++ b/rules-bank/run_books/guided_ttp_hunt_credential_access.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Guided TTP Hunt Runbook (Example: Credential Access)"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Guided TTP Hunt Runbook (Example: Credential Access)
 
 ## Objective

--- a/rules-bank/run_books/guidelines/report_writing.md
+++ b/rules-bank/run_books/guidelines/report_writing.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: "Runbook: Report Writing Guidelines & Template"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Runbook: Report Writing Guidelines & Template
 
 ## Objective

--- a/rules-bank/run_books/guidelines/runbook_guidelines.md
+++ b/rules-bank/run_books/guidelines/runbook_guidelines.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Runbook Guidelines
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Runbook Guidelines
 
 This document provides general guidelines for creating, maintaining, and executing runbooks within this security environment.

--- a/rules-bank/run_books/guidelines/soc_analyst_workflows.md
+++ b/rules-bank/run_books/guidelines/soc_analyst_workflows.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: "Runbook: SOC Analyst Standard Workflow Guide"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Runbook: SOC Analyst Standard Workflow Guide
 
 ## Objective

--- a/rules-bank/run_books/guidelines/threat_intel_workflows.md
+++ b/rules-bank/run_books/guidelines/threat_intel_workflows.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: "Runbook: Threat Intelligence Workflows"
+generated:
+  by: human:dandye
+  at: 2025-11-10T17:21:35-05:00
+---
+
 # Runbook: Threat Intelligence Workflows
 
 ## Objective

--- a/rules-bank/run_books/investigate_a_case_w_external_tools.md
+++ b/rules-bank/run_books/investigate_a_case_w_external_tools.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Investigate a Case + external tools
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Investigate a Case + external tools
 
 Using SecOps, GTI, and Okta. Start with a Case (anomalous login Alerts). Find the entities involved and look up any related indicators. Find any users involved and look up Okta information to determine any suspicious characteristics. If confident in disposition, disable that User. Finally, provide a report about any identified activity for security analyst consumption.

--- a/rules-bank/run_books/investigate_a_gti_collection_id.md
+++ b/rules-bank/run_books/investigate_a_gti_collection_id.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Investigate Google Threat Intelligence Collection ID (Enhanced)
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Investigate Google Threat Intelligence Collection ID (Enhanced)
 
 Objective: Investigate Google Threat Intelligence Collection ID provided by the user `${COLLECTION_ID}`. Enrich findings with detailed entity reports and correlate with the local environment (SIEM/SOAR). Create a timestamped markdown report summarizing findings, correlations, and recommended actions.

--- a/rules-bank/run_books/ioc_containment.md
+++ b/rules-bank/run_books/ioc_containment.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: IOC Containment Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # IOC Containment Runbook
 
 ## Objective

--- a/rules-bank/run_books/ioc_threat_hunt.md
+++ b/rules-bank/run_books/ioc_threat_hunt.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: IOC Threat Hunt"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: IOC Threat Hunt
 
 ## Objective

--- a/rules-bank/run_books/irps/compromised_user_account_response.md
+++ b/rules-bank/run_books/irps/compromised_user_account_response.md
@@ -1,3 +1,11 @@
+---
+type: Incident Response Plan
+title: Compromised User Account Incident Response Plan (IRP) / Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Compromised User Account Incident Response Plan (IRP) / Runbook
 
 ## Objective

--- a/rules-bank/run_books/irps/malware_incident_response.md
+++ b/rules-bank/run_books/irps/malware_incident_response.md
@@ -1,3 +1,11 @@
+---
+type: Incident Response Plan
+title: Malware Incident Response Plan (IRP) Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Malware Incident Response Plan (IRP) Runbook
 
 ## Objective

--- a/rules-bank/run_books/irps/phishing_response.md
+++ b/rules-bank/run_books/irps/phishing_response.md
@@ -1,3 +1,11 @@
+---
+type: Incident Response Plan
+title: Phishing Incident Response Plan (IRP) / Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Phishing Incident Response Plan (IRP) / Runbook
 
 ## Objective

--- a/rules-bank/run_books/irps/ransomware_response.md
+++ b/rules-bank/run_books/irps/ransomware_response.md
@@ -1,3 +1,11 @@
+---
+type: Incident Response Plan
+title: Ransomware Incident Response Plan (IRP) / Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Ransomware Incident Response Plan (IRP) / Runbook
 
 ## Objective

--- a/rules-bank/run_books/lateral_movement_hunt_psexec_wmi.md
+++ b/rules-bank/run_books/lateral_movement_hunt_psexec_wmi.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Lateral Movement Detection Hunt (Example: PsExec/WMI)"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Lateral Movement Detection Hunt (Example: PsExec/WMI)
 
 ## Objective

--- a/rules-bank/run_books/malware_triage.md
+++ b/rules-bank/run_books/malware_triage.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Malware Triage Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Malware Triage Runbook
 
 ## Objective

--- a/rules-bank/run_books/metaanalysis.md
+++ b/rules-bank/run_books/metaanalysis.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Meta-Analysis (Placeholder)"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Meta-Analysis (Placeholder)
 
 ## Objective

--- a/rules-bank/run_books/post_incident_review.md
+++ b/rules-bank/run_books/post_incident_review.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Post-Incident Review (PIR) Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Post-Incident Review (PIR) Runbook
 
 ## Objective

--- a/rules-bank/run_books/prioritize_and_investigate_a_case.md
+++ b/rules-bank/run_books/prioritize_and_investigate_a_case.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Prioritize and Investigate a Case
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Prioritize and Investigate a Case
 
 From a list of cases, identify cases of the highest severity and potential impact based on underlying alerts and detections. Get rule logic to validate the detections in the cases. After identifying the highest N priority cases -> Explain the entirety of the case to the analyst in the context of the underlying rule logic (explain the rule logic and how it applies to this case). Get entity context to determine if there are additional alerts, detections, or events that may not have been included in the case but are potentially applicable.

--- a/rules-bank/run_books/proactive_threat_hunting_based_on_gti_campaign_or_actor.md
+++ b/rules-bank/run_books/proactive_threat_hunting_based_on_gti_campaign_or_actor.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Proactive Threat Hunting based on GTI Campaign/Actor
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Proactive Threat Hunting based on GTI Campaign/Actor
 
 Objective: Given a GTI Campaign or Threat Actor Collection ID (`${GTI_COLLECTION_ID}`), proactively search the local environment (SIEM) for related IOCs and TTPs (approximated by searching related entities). If any IOCs from the report are also found in the SecOps tenant (confirmed presence), perform deeper enrichment on those specific IOCs using GTI and check for related SIEM alerts or SOAR cases. Once done, summarize findings in a markdown report. Provide as much detail as possible.

--- a/rules-bank/run_books/suspicious_login_triage.md
+++ b/rules-bank/run_books/suspicious_login_triage.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: Suspicious Login Alert Triage Runbook
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Suspicious Login Alert Triage Runbook
 
 ## Objective

--- a/rules-bank/run_books/triage_alerts.md
+++ b/rules-bank/run_books/triage_alerts.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: Alert Triage"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: Alert Triage
 
 ## Objective

--- a/rules-bank/run_books/ueba_report.md
+++ b/rules-bank/run_books/ueba_report.md
@@ -1,3 +1,11 @@
+---
+type: Runbook
+title: "Runbook: UEBA Report Analysis"
+generated:
+  by: process:google-labs-jules
+  at: 2025-12-20T22:04:42-05:00
+---
+
 # Runbook: UEBA Report Analysis
 
 ## Objective

--- a/rules-bank/runbook_templates/atomic_runbook_template.md
+++ b/rules-bank/runbook_templates/atomic_runbook_template.md
@@ -1,3 +1,11 @@
+---
+type: Template
+title: "Atomic Runbook: [Clear, Verb-Oriented Title - e.g., Get_IP_Reputation_From_GTI]"
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # Atomic Runbook: [Clear, Verb-Oriented Title - e.g., Get_IP_Reputation_From_GTI]
 
 **ID:** `RB-ATOM-[UniqueSequentialID]` (e.g., RB-ATOM-001)

--- a/rules-bank/sop_automation_effectiveness_review.md
+++ b/rules-bank/sop_automation_effectiveness_review.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: SOP & Automation Effectiveness Review Process
+generated:
+  by: human:dandye
+  at: 2025-05-31T00:07:07-04:00
+---
+
 # SOP & Automation Effectiveness Review Process
 
 This document outlines the process for periodically reviewing the effectiveness of Standard Operating Procedures (SOPs)/runbooks and their associated automation. The goal is to ensure they remain efficient, relevant, and aligned with the organization's security posture and the capabilities of both human analysts and AI agents. This supports the "Optimization & Metrics" aspect of the Detection Engineering lifecycle and the "Learning" phase of the PICERL framework.

--- a/rules-bank/suggested_mcp_tools.md
+++ b/rules-bank/suggested_mcp_tools.md
@@ -1,3 +1,11 @@
+---
+type: Guideline
+title: Suggested New MCP Tools
+generated:
+  by: human:dandye
+  at: 2025-05-17T18:46:00-04:00
+---
+
 # Suggested New MCP Tools
 
 Based on the current toolsets for SecOps (SIEM), SOAR, GTI, and SCC, and considering the workflows outlined in the runbooks and personas, here are some potential new MCP tools that could significantly enhance the agent's (and analysts') capabilities:

--- a/rules-bank/tools/SCC_MCP_TOOLS_REFERENCE.md
+++ b/rules-bank/tools/SCC_MCP_TOOLS_REFERENCE.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: SCC MCP Tools Reference
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # SCC MCP Tools Reference
 
 This document provides a reference for the tools available in the SCC MCP server.

--- a/rules-bank/tools/SECOPS_MCP_TOOLS_REFERENCE.md
+++ b/rules-bank/tools/SECOPS_MCP_TOOLS_REFERENCE.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: SecOps MCP Tools Reference
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # SecOps MCP Tools Reference
 
 This document provides a reference for the tools available in the SecOps MCP server.

--- a/rules-bank/tools/SOAR_MCP_TOOLS_REFERENCE.md
+++ b/rules-bank/tools/SOAR_MCP_TOOLS_REFERENCE.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: SOAR MCP Tools Reference
+generated:
+  by: human:dandye
+  at: 2025-06-19T21:01:22-04:00
+---
+
 # SOAR MCP Tools Reference
 
 This document provides a reference for the tools available in the SOAR MCP server.


### PR DESCRIPTION
## Summary

Adds net-new [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) frontmatter to this repo's markdown content. Unlike `ai-runbooks` (a sibling repo migrated in a companion PR), **none** of adk_runbooks' 142 markdown files had any existing frontmatter, so this is additive rather than a migration.

128 of the 142 files get a new frontmatter block:

- **`type`** (the one OKF-required field), assigned by directory convention:
  - `Persona` — `rules-bank/personas/`
  - `Runbook` — `rules-bank/run_books/`, `common_steps/`, `atomic_runbooks/`
  - `Incident Response Plan` — `rules-bank/run_books/irps/`
  - `Guideline` — top-level rules-bank docs, `ai/`, `guidelines/`
  - `Template` — `runbook_templates/`, `detection_use_cases/`
  - `Reference` — `tools/`, `multi_agent/`, READMEs
  - `Report` — `reports/`, `dac-agent/reports/`, `multi-agent/reports/`
- **`title`** — extracted from each file's first `# Heading`. A few files had no clean H1 (a chat-transcript-style report, a bare timestamp dump, one file whose real title was an H2); those got hand-fixed titles rather than the raw filename-derived fallback.
- **`generated: { by, at }`** (OKF §5.2) — derived from each file's last git commit, author mapped to the OKF actor convention (`human:dandye`, `process:google-labs-jules`).

## Deliberately not added

- **`description`/`tags`** — synthesizing an accurate one-sentence summary per file means actually reading and understanding each one; that's a content-review task, not a mechanical migration. Flagging as a follow-up rather than guessing.
- **`index.md` files** (14 of them) — OKF §3.1 reserves this filename for directory listings and disallows regular frontmatter on it. Left untouched.

## Verification

- All 128 updated files' frontmatter re-parses as valid YAML (`yaml.safe_load`) with a non-empty `type`.
- Diffs are pure prepends — no existing body content changed.